### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ Where "message text" is:
     * "Invalid course option for this Standard. Must be one of the following: 'list of course options'"
     where 'list of course options' depends on the standard code, and can be obtained with 
     ```http 
-    GET api/v1/certificate/options/(standard}
+    GET api/v1/standards/options/(standard}
     ```
 - OverallGrade
     * "Select the grade the apprentice achieved"
@@ -955,8 +955,8 @@ The full list of options can be provided, or the list can be filtered by a stand
 **Request**
 
 ```http
-GET /api/v1/certificate/options
-GET /api/v1/certificate/options/{standard}
+GET /api/v1/standards/options
+GET /api/v1/standards/options/{standard}
 ```
 
 Request can either use numeric "standardCode" (LARS Standard code) or "standardReference" (IFA STxxxx reference) for \{standard}..


### PR DESCRIPTION
change standards options to correct URL's from the swagger docs at https://developers.apprenticeships.education.gov.uk/docs/services/assessor-service-api-sandbox